### PR TITLE
allow endpoint spec to specify additional ingress annotations

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -680,6 +680,7 @@ func (ar *AppRuntime) createHttpIngress(e *spec.EndpointSpec) error {
 		ar.spaceSpec.EncryptHttp,
 		secName,
 		e.HttpLocalhostOnly,
+		e.AdditionalIngressAnnotations,
 	)
 }
 
@@ -708,6 +709,12 @@ func (ar *AppRuntime) createTcpIngress(
 	if hostName == "" {
 		hostName = e.Name + "." + ar.namespace + "." + ar.spaceSpec.DomainName
 	}
+	anno := make(map[string]string)
+	// Copy additional annotations. Note: this works if the source map is nil
+	for key, val := range e.AdditionalIngressAnnotations {
+		anno[key] = val
+	}
+	anno["kubernetes.io/ingress.class"] = "k8sniff"
 	ingApi := ar.kubeApi.ExtensionsV1beta1().Ingresses(ar.namespace)
 	ing := v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -716,9 +723,7 @@ func (ar *AppRuntime) createTcpIngress(
 				"decco-derived-from": "app",
 				"decco-app": ar.Name(),
 			},
-			Annotations: map[string]string {
-				"kubernetes.io/ingress.class": "k8sniff",
-			},
+			Annotations: anno,
 		},
 		Spec: v1beta1.IngressSpec{
 			Rules: []v1beta1.IngressRule{

--- a/pkg/appspec/app_rsc.go
+++ b/pkg/appspec/app_rsc.go
@@ -124,6 +124,8 @@ type EndpointSpec struct {
 	DisableTlsTermination bool `json:"disableTlsTermination"`
 	DisableTcpClientTlsVerification bool   `json:"disableTcpClientTlsVerification"`
 	SniHostname string   `json:"sniHostname"` // optional SNI hostname override
+	// Optional ingress resource annotations
+	AdditionalIngressAnnotations map[string]string `json:"additionalIngressAnnotations,omitempty"`
 }
 
 // -----------------------------------------------------------------------------

--- a/pkg/k8sutil/ingress.go
+++ b/pkg/k8sutil/ingress.go
@@ -21,10 +21,15 @@ func CreateHttpIngress(
 	encryptHttp bool,
 	secretName string,
 	localhostOnly bool,
+	additionalAnnotations map[string]string,
 ) error {
 	ingApi := kubeApi.ExtensionsV1beta1().Ingresses(ns)
 	annotations := make(map[string]string)
-
+	// Copy over additional annotations.
+	// Note: this works even if additionalAnnotations is nil
+	for key, val := range additionalAnnotations{
+		annotations[key] = val
+	}
 	// temporary hack to work around nginx-to-stunnel timeouts during heavy load
 	annotations["nginx.ingress.kubernetes.io/proxy-connect-timeout"] = "15"
 	// some services like caproxy sometimes take longer than a minute to respond

--- a/pkg/space/space.go
+++ b/pkg/space/space.go
@@ -407,6 +407,7 @@ func (c *SpaceRuntime) createHttpIngress() error {
 		c.Space.Spec.EncryptHttp,
 		c.Space.Spec.HttpCertSecretName,
 		false,
+		nil,
 	)
 }
 


### PR DESCRIPTION
Use cases:
1. Enable CORS on some HTTP endpoints
2. Allow some endpoints to specify custom nginx configuration snippets