### PR TITLE
Private/leb/rscmgmt

### DIFF
--- a/pkg/k8sutil/stunnel.go
+++ b/pkg/k8sutil/stunnel.go
@@ -3,6 +3,7 @@ package k8sutil
 import (
 	"fmt"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const TlsPort = 443
@@ -127,6 +128,16 @@ func InsertStunnel(
 				Name: volumeName,
 				ReadOnly: true,
 				MountPath: "/etc/stunnel/certs",
+			},
+		},
+		// stunnel has been observed to consume between 3 and 6 MB, so
+		// set request to 5 and limit to 10
+		Resources: v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				"memory": resource.MustParse("5Mi"),
+			},
+			Limits: v1.ResourceList{
+				"memory": resource.MustParse("10Mi"),
 			},
 		},
 	})

--- a/pkg/k8sutil/stunnel.go
+++ b/pkg/k8sutil/stunnel.go
@@ -131,12 +131,15 @@ func InsertStunnel(
 			},
 		},
 		// stunnel has been observed to consume between 3 and 6 MB, so
-		// set request to 5 and limit to 10
+		// set memory request to 5 and limit to 10.
+		// Also limit cpu usage to 1 whole CPU
 		Resources: v1.ResourceRequirements{
 			Requests: v1.ResourceList{
+				"cpu": resource.MustParse("15m"),
 				"memory": resource.MustParse("5Mi"),
 			},
 			Limits: v1.ResourceList{
+				"cpu": resource.MustParse("1000m"),
 				"memory": resource.MustParse("10Mi"),
 			},
 		},

--- a/pkg/k8sutil/stunnel.go
+++ b/pkg/k8sutil/stunnel.go
@@ -135,7 +135,7 @@ func InsertStunnel(
 		// Also limit cpu usage to 1 whole CPU
 		Resources: v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				"cpu": resource.MustParse("15m"),
+				"cpu": resource.MustParse("5m"),
 				"memory": resource.MustParse("5Mi"),
 			},
 			Limits: v1.ResourceList{

--- a/pkg/space/space.go
+++ b/pkg/space/space.go
@@ -662,7 +662,10 @@ func (c *SpaceRuntime) createPrivateIngressController() error {
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								"cpu": resource.MustParse("100m"),
-								"memory": resource.MustParse("32Mi"),
+								"memory": resource.MustParse("110Mi"),
+							},
+							Limits: v1.ResourceList{
+								"memory": resource.MustParse("150Mi"),
 							},
 						},
 					},

--- a/pkg/space/space.go
+++ b/pkg/space/space.go
@@ -665,6 +665,7 @@ func (c *SpaceRuntime) createPrivateIngressController() error {
 								"memory": resource.MustParse("110Mi"),
 							},
 							Limits: v1.ResourceList{
+								"cpu": resource.MustParse("1000m"),
 								"memory": resource.MustParse("150Mi"),
 							},
 						},


### PR DESCRIPTION
decco changes for better resource management based on empirical observations:
- set memory request and limit for stunnel
- reconfigure nginx-ingress mem request/limit
