### PR TITLE
make ingress controller image configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ $(KLOG): | $(GOPATH_DIR)
 $(CLIENTGO): | $(GODEP) $(GOPATH_DIR) $(KLOG) $(OPENAPIV2_SYMLINK)
 	go get k8s.io/client-go/...
 
-$(OPENAPIV2_SYMLINK):
+$(OPENAPIV2_SYMLINK): $(GO_DEPS)
 	cd $(GOSRC)/github.com/googleapis/gnostic && ln -s openapiv2 OpenAPIv2
 
 openapi_symlink: $(OPENAPIV2_SYMLINK)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,10 @@ GO_DEPS := \
 	$(GOSRC)/github.com/pborman/uuid \
 	$(GOSRC)/github.com/cenkalti/backoff \
 	$(GOSRC)/github.com/sirupsen/logrus \
+	$(GOSRC)/github.com/googleapis/gnostic \
 	$(GOSRC)/k8s.io/federation/pkg/dnsprovider
+
+OPENAPIV2_SYMLINK := $(GOSRC)/github.com/googleapis/gnostic/OpenAPIv2
 
 IMAGE_NAME := decco-operator
 
@@ -69,8 +72,14 @@ $(KLOG): | $(GOPATH_DIR)
 	go get k8s.io/klog
 	cd $@ && git checkout v0.4.0
 
-$(CLIENTGO): | $(GODEP) $(GOPATH_DIR) $(KLOG)
+
+$(CLIENTGO): | $(GODEP) $(GOPATH_DIR) $(KLOG) $(OPENAPIV2_SYMLINK)
 	go get k8s.io/client-go/...
+
+$(OPENAPIV2_SYMLINK):
+	cd $(GOSRC)/github.com/googleapis/gnostic && ln -s openapiv2 OpenAPIv2
+
+openapi_symlink: $(OPENAPIV2_SYMLINK)
 
 symlinks: | $(DECCO_SYMLINKS)
 
@@ -80,6 +89,8 @@ $(GO_DEPS): $(GOPATH_DIR)
 	go get $(subst $(GOSRC)/,,$@)
 
 godeps: | $(GO_DEPS)
+
+klog: | $(KLOG)
 
 $(OPERATOR_STAGE_DIR):
 	mkdir -p $@

--- a/pkg/appcontroller/watch_namespace.go
+++ b/pkg/appcontroller/watch_namespace.go
@@ -1,6 +1,7 @@
 package appcontroller
 
 import (
+	"context"
 	"github.com/platform9/decco/pkg/k8sutil"
 	"github.com/platform9/decco/pkg/watcher"
 	"k8s.io/client-go/kubernetes"
@@ -112,11 +113,12 @@ func (ctl *Controller) watchNamespaceInternal(
 	}
 	log.Infof("watching namespace at rv %s", resourceVersion)
 	for {
+		ctx := context.Background()
 		w, err := restClient.
 			Get().
 			Resource("namespaces").
 			VersionedParams(&listOpts, scheme.ParameterCodec).
-			Watch()
+			Watch(ctx)
 
 		if err != nil {
 			return false, fmt.Errorf("failed to watch namespace: %s", err)

--- a/pkg/k8sutil/app_rsc_def.go
+++ b/pkg/k8sutil/app_rsc_def.go
@@ -15,6 +15,7 @@
 package k8sutil
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -36,8 +37,8 @@ func WatchApps(host string, ns string, httpClient *http.Client, resourceVersion 
 
 func GetAppList(restcli rest.Interface,
 	ns string) (*spec.AppList, error) {
-
-	b, err := restcli.Get().RequestURI(listAppsURI(ns)).DoRaw()
+	ctx := context.Background()
+	b, err := restcli.Get().RequestURI(listAppsURI(ns)).DoRaw(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +68,8 @@ func UpdateAppCustRsc(
 		ns,
 		spec.CRDResourcePlural,
 		c.Name)
-	b, err := restcli.Put().RequestURI(uri).Body(&c).DoRaw()
+	ctx := context.Background()
+	b, err := restcli.Put().RequestURI(uri).Body(&c).DoRaw(ctx)
 	if err != nil {
 		return spec.App{}, err
 	}

--- a/pkg/k8sutil/cust_rsc_def.go
+++ b/pkg/k8sutil/cust_rsc_def.go
@@ -15,6 +15,7 @@
 package k8sutil
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -35,8 +36,8 @@ func WatchSpaces(host string, httpClient *http.Client, resourceVersion string) (
 }
 
 func GetSpaceList(restcli rest.Interface) (*spec.SpaceList, error) {
-
-	b, err := restcli.Get().RequestURI(listSpacesURI()).DoRaw()
+	ctx := context.Background()
+	b, err := restcli.Get().RequestURI(listSpacesURI()).DoRaw(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +64,8 @@ func UpdateSpaceCustRsc(
 		c.Namespace,
 		spec.CRDResourcePlural,
 		c.Name)
-	b, err := restcli.Put().RequestURI(uri).Body(&c).DoRaw()
+	ctx := context.Background()
+	b, err := restcli.Put().RequestURI(uri).Body(&c).DoRaw(ctx)
 	if err != nil {
 		return spec.Space{}, err
 	}

--- a/pkg/space/space.go
+++ b/pkg/space/space.go
@@ -616,6 +616,12 @@ func (c *SpaceRuntime) createPrivateIngressController() error {
 			SniHostname: epName + "." + hostName,
 		})
 	}
+	ingressControllerImage := os.Getenv("INGRESS_CONTROLLER_IMAGE")
+	if ingressControllerImage == "" {
+		// default to a manually built image that has a fix for CORE-843
+		ingressControllerImage = "platform9/ingress-nginx:0.19.0-006"
+	}
+
 	app := appspec.App{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "nginx-ingress",
@@ -649,8 +655,7 @@ func (c *SpaceRuntime) createPrivateIngressController() error {
 								},
 							},
 						},
-						//Image: "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.19.0",
-						Image: "platform9systems/nginx-ingress-controller:106",
+						Image: ingressControllerImage,
 						Ports: []v1.ContainerPort{
 							{
 								ContainerPort: int32(443),
@@ -663,11 +668,11 @@ func (c *SpaceRuntime) createPrivateIngressController() error {
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								"cpu": resource.MustParse("100m"),
-								"memory": resource.MustParse("110Mi"),
+								"memory": resource.MustParse("200Mi"),
 							},
 							Limits: v1.ResourceList{
 								"cpu": resource.MustParse("1000m"),
-								"memory": resource.MustParse("150Mi"),
+								"memory": resource.MustParse("200Mi"),
 							},
 						},
 					},

--- a/pkg/space/space.go
+++ b/pkg/space/space.go
@@ -1,6 +1,7 @@
 package space
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -677,9 +678,10 @@ func (c *SpaceRuntime) createPrivateIngressController() error {
 	}
 	var rtObj runtime.Object
 	rtObj = &app
+	ctx := context.Background()
 	err = restCli.Post().Namespace(c.Space.Name).
 		Resource(appspec.CRDResourcePlural).
-		Body(rtObj).Do().Into(nil)
+		Body(rtObj).Do(ctx).Into(nil)
 	return err
 }
 


### PR DESCRIPTION
* allow ingress controller image to be configured via environment variable
* default to an image known to have a fix for CORE-843 (child process restart issue)
* increase memory request and limit (and make them identical) to reduce the likelihood of OOM-kill of the nginx process