### PR TITLE
introduce TcpHostnameSuffix and JobBackoffLimit

### DIFF
--- a/pkg/app/gc.go
+++ b/pkg/app/gc.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"github.com/sirupsen/logrus"
@@ -23,7 +24,8 @@ func collectDeployments(kubeApi kubernetes.Interface,
 
 	log = log.WithField("func", "collectDeployments")
 	deplApi := kubeApi.ExtensionsV1beta1().Deployments(namespace)
-	nses, err := deplApi.List(
+	ctx := context.Background()
+	nses, err := deplApi.List(ctx,
 		metav1.ListOptions{
 			LabelSelector: "decco-derived-from=app",
 		},
@@ -38,7 +40,7 @@ func collectDeployments(kubeApi kubernetes.Interface,
 			log.Infof("deleting orphaned deployment %s", ns.Name)
 			propPolicy := metav1.DeletePropagationBackground
 			delOpts := metav1.DeleteOptions{PropagationPolicy: &propPolicy}
-			err = deplApi.Delete(ns.Name, &delOpts)
+			err = deplApi.Delete(ctx, ns.Name, &delOpts)
 			if err != nil {
 				log.Warnf("failed to delete deployment %s: %s",
 					ns.Name, err.Error())
@@ -54,7 +56,8 @@ func collectServices(kubeApi kubernetes.Interface,
 
 	log = log.WithField("func", "collectServices")
 	svcApi := kubeApi.CoreV1().Services(namespace)
-	svcs, err := svcApi.List(
+	ctx := context.Background()
+	svcs, err := svcApi.List(ctx,
 		metav1.ListOptions{
 			LabelSelector: "decco-derived-from=app",
 		},
@@ -73,7 +76,7 @@ func collectServices(kubeApi kubernetes.Interface,
 		}
 		if !isKnownApp(appName) {
 			log.Infof("deleting orphaned service %s", svc.Name)
-			err = svcApi.Delete(svc.Name, nil)
+			err = svcApi.Delete(ctx, svc.Name, nil)
 			if err != nil {
 				log.Warnf("failed to delete service %s: %s",
 					svc.Name, err.Error())
@@ -89,7 +92,8 @@ func collectIngresses(kubeApi kubernetes.Interface,
 
 	log = log.WithField("func", "collectIngresses")
 	ingApi := kubeApi.ExtensionsV1beta1().Ingresses(namespace)
-	ingList, err := ingApi.List(
+	ctx := context.Background()
+	ingList, err := ingApi.List(ctx,
 		metav1.ListOptions{
 			LabelSelector: "decco-derived-from=app",
 		},
@@ -107,7 +111,7 @@ func collectIngresses(kubeApi kubernetes.Interface,
 			log.Infof("deleting orphaned ingress '%s'", ing.Name)
 			propPolicy := metav1.DeletePropagationBackground
 			delOpts := metav1.DeleteOptions{PropagationPolicy: &propPolicy}
-			err = ingApi.Delete(ing.Name, &delOpts)
+			err = ingApi.Delete(ctx, ing.Name, &delOpts)
 			if err != nil {
 				log.Warnf("failed to delete ingress %s: %s",
 					ing.Name, err.Error())

--- a/pkg/appcontroller/watch_namespace.go
+++ b/pkg/appcontroller/watch_namespace.go
@@ -43,7 +43,7 @@ func (ctl *Controller) shutdownWhenNamespaceGone() {
 	nsApi := kubeApi.CoreV1().Namespaces()
 	restClient := kubeApi.CoreV1().RESTClient()
 	sleepSeconds := 0
-
+	ctx := context.Background()
 	for {
 		select {
 		case <- ctl.stopCh:
@@ -57,7 +57,7 @@ func (ctl *Controller) shutdownWhenNamespaceGone() {
 		}
 		sleepSeconds += retryDelayIncrement
 		fs := fmt.Sprintf("metadata.name=%s", ctl.namespace)
-		nsList, err := nsApi.List(meta_v1.ListOptions{FieldSelector: fs})
+		nsList, err := nsApi.List(ctx, meta_v1.ListOptions{FieldSelector: fs})
 		if err != nil {
 			log.Warnf("failed to list namespaces %s", err)
 			continue

--- a/pkg/appspec/app_rsc.go
+++ b/pkg/appspec/app_rsc.go
@@ -98,6 +98,7 @@ type AppSpec struct {
 	InitialReplicas int32 `json:"initialReplicas"`
 	Egresses        []TlsEgress
 	RunAsJob        bool `json:"runAsJob"`
+	JobBackoffLimit int32 `json:"jobBackoffLimit"`
 	Endpoints       []EndpointSpec
 	FirstEndpointListenPort int32
 	Permissions     []rbacv1.PolicyRule
@@ -112,6 +113,7 @@ type EndpointSpec struct {
 	// optional Cert and CA if don't want to use default one for the space
 	CertAndCaSecretName string `json:"certAndCaSecretName"`
 	CreateClearTextSvc  bool   `json:"createClearTextSvc"`
+
 	// The following only apply to http endpoints (httpPath not empty)
 	// RewritePath value is interpreted as follows:
 	// empty: the path is forwarded unmodified
@@ -119,11 +121,18 @@ type EndpointSpec struct {
 	HttpPath             string `json:"httpPath"`
 	RewritePath          string `json:"rewritePath"`
 	HttpLocalhostOnly bool `json:"httpLocalhostOnly"`
+
 	// The following only apply to tcp endpoints (httpPath empty)
 	CreateDnsRecord     bool   `json:"createDnsRecord"`
 	DisableTlsTermination bool `json:"disableTlsTermination"`
 	DisableTcpClientTlsVerification bool   `json:"disableTcpClientTlsVerification"`
 	SniHostname string   `json:"sniHostname"` // optional SNI hostname override
+	// Optional name suffix to append to server name for SNI routing purposes.
+	// For e.g., if endpoint name is "foo", space domain name is "bar.com",
+	// and nameSuffix is ".v0", then the SNI routing name becomes:
+	// foo.v0.bar.com
+	TcpHostnameSuffix           string `json:"tcpHostnameSuffix"`
+
 	// Optional ingress resource annotations
 	AdditionalIngressAnnotations map[string]string `json:"additionalIngressAnnotations,omitempty"`
 }

--- a/pkg/k8sutil/app_rsc_def.go
+++ b/pkg/k8sutil/app_rsc_def.go
@@ -101,13 +101,16 @@ func CreateAppCRD(clientset apiextensionsclient.Interface) error {
 			},
 		},
 	}
-	_, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
+	ctx := context.Background()
+	_, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(ctx, crd)
 	return err
 }
 
 func WaitAppCRDReady(clientset apiextensionsclient.Interface) error {
 	err := retryutil.Retry(5*time.Second, 20, func() (bool, error) {
-		crd, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(spec.CRDName, metav1.GetOptions{})
+		ctx := context.Background()
+		crd, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(
+			ctx, spec.CRDName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/pkg/k8sutil/cust_rsc_def.go
+++ b/pkg/k8sutil/cust_rsc_def.go
@@ -97,13 +97,16 @@ func CreateCRD(clientset apiextensionsclient.Interface) error {
 			},
 		},
 	}
-	_, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
+	ctx := context.Background()
+	_, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(ctx, crd)
 	return err
 }
 
 func WaitCRDReady(clientset apiextensionsclient.Interface) error {
 	err := retryutil.Retry(5*time.Second, 20, func() (bool, error) {
-		crd, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(spec.CRDName, metav1.GetOptions{})
+		ctx := context.Background()
+		crd, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(
+			ctx, spec.CRDName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/pkg/k8sutil/ingress.go
+++ b/pkg/k8sutil/ingress.go
@@ -1,6 +1,7 @@
 package k8sutil
 
 import (
+	"context"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,6 +89,7 @@ func CreateHttpIngress(
 			TLS: tls,
 		},
 	}
-	_, err := ingApi.Create(&ing)
+	ctx := context.Background()
+	_, err := ingApi.Create(ctx, &ing)
 	return err
 }

--- a/pkg/k8sutil/misc.go
+++ b/pkg/k8sutil/misc.go
@@ -1,6 +1,7 @@
 package k8sutil
 
 import (
+	"context"
 	"fmt"
 	"k8s.io/client-go/kubernetes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -8,7 +9,8 @@ import (
 
 func GetTcpIngressIpOrHostname(kubeApi kubernetes.Interface) (string, bool, error) {
 	svcApi := kubeApi.CoreV1().Services("decco")
-	svc, err := svcApi.Get("k8sniff", metav1.GetOptions{})
+	ctx := context.Background()
+	svc, err := svcApi.Get(ctx, "k8sniff", metav1.GetOptions{})
 	if err != nil {
 		return "", false, fmt.Errorf("failed to get k8sniff service: %s", err)
 	}

--- a/pkg/space/gc.go
+++ b/pkg/space/gc.go
@@ -1,6 +1,7 @@
 package space
 
 import (
+	"context"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +14,8 @@ func Collect(kubeApi kubernetes.Interface,
 
 	log = log.WithField("func", "collect")
 	nsApi := kubeApi.CoreV1().Namespaces()
-	nses, err := nsApi.List(
+	ctx := context.Background()
+	nses, err := nsApi.List(ctx,
 		meta_v1.ListOptions{
 			LabelSelector: "app=decco",
 		},
@@ -31,7 +33,7 @@ func Collect(kubeApi kubernetes.Interface,
 				continue
 			}
 			log.Infof("deleting orphaned namespace %s", ns.Name)
-			err = nsApi.Delete(ns.Name, nil)
+			err = nsApi.Delete(ctx, ns.Name, nil)
 			if err != nil {
 				log.Warnf("failed to delete namespace %s: %s",
 					ns.Name, err.Error())

--- a/pkg/spec/space_rsc.go
+++ b/pkg/spec/space_rsc.go
@@ -83,6 +83,8 @@ type SpaceSpec struct {
 	DisablePrivateIngressController bool `json:"disablePrivateIngressController"`
 	VerboseIngressControllerLogging bool `json:"verboseIngressControllerLogging"`
 	PrivateIngressControllerTcpEndpoints []string `json:"privateIngressControllerTcpEndpoints"`
+	// Optional suffix to append to host names of private ingress controller's tcp endpoints
+	PrivateIngressControllerTcpHostnameSuffix string `json:"privateIngressControllerTcpHostnameSuffix"`
 	Permissions *SpacePermissions `json:permissions`
 	CreateDefaultHttpDeploymentAndIngress bool `json:createDefaultHttpDeploymentAndIngress`
 }


### PR DESCRIPTION
**TcpHostnameSuffix** and **PrivateIngressControllerTcpHostnameSuffix** were introduced to fix CORE-850. They allow the app creator to specify an additional suffix to add to hostnames.

**JobBackoffLimit** allows the app spec author to override the backoffLimit field of job resources. It defaults to 6 in Kubernetes, but it's sometimes useful to set it to zero to avoid retries on certain jobs.

Additionally, had to update decco code to keep up with a recent Kubernetes and Client-Go change: all API requests must now supply a Context structure