### PR TITLE
Format the Go codebase

### DIFF
--- a/cmd/appclient-test/appclient-test.go
+++ b/cmd/appclient-test/appclient-test.go
@@ -19,14 +19,16 @@ package main
 
 import (
 	"flag"
-	"github.com/platform9/decco/pkg/appspec"
-	"github.com/platform9/decco/pkg/client"
-	"github.com/platform9/decco/pkg/k8sutil"
+
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/klog"
+
+	"github.com/platform9/decco/pkg/appspec"
+	"github.com/platform9/decco/pkg/client"
+	"github.com/platform9/decco/pkg/k8sutil"
 )
 
 func main() {
@@ -51,6 +53,3 @@ func main() {
 		log.Fatalf("failed to create app: %s", err)
 	}
 }
-
-
-

--- a/cmd/default-http/default_http.go
+++ b/cmd/default-http/default_http.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 	"log"
+	"net/http"
 	"os"
 	"strconv"
 )
@@ -39,6 +39,3 @@ func main() {
 		log.Fatalf("listen failed: %s", err)
 	}
 }
-
-
-

--- a/cmd/dns-test/dnstest.go
+++ b/cmd/dns-test/dnstest.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	_ "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/aws/route53"
-	"github.com/sirupsen/logrus"
-	"fmt"
 	"flag"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	_ "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/aws/route53"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
 )
 

--- a/cmd/namespace-watcher-with-field-selector/one_ns_watcher_with_field_selector.go
+++ b/cmd/namespace-watcher-with-field-selector/one_ns_watcher_with_field_selector.go
@@ -18,14 +18,16 @@ limitations under the License.
 package main
 
 import (
-	//	"k8s.io/client-go/kubernetes/typed/core/v1"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"k8s.io/client-go/kubernetes"
-	log "github.com/sirupsen/logrus"
-	"github.com/platform9/decco/pkg/k8sutil"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	scheme "k8s.io/client-go/kubernetes/scheme"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	scheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	//	"k8s.io/client-go/kubernetes/typed/core/v1"
+	"github.com/platform9/decco/pkg/k8sutil"
 )
 
 func main() {
@@ -33,7 +35,7 @@ func main() {
 	kubeApi := kubernetes.NewForConfigOrDie(restConfig)
 	restClient := kubeApi.CoreV1().RESTClient()
 	listOpts := meta_v1.ListOptions{
-		Watch: true,
+		Watch:         true,
 		FieldSelector: "metadata.name=decco",
 	}
 	for {
@@ -48,7 +50,7 @@ func main() {
 		} else {
 			events := watcher.ResultChan()
 			for {
-				event := <- events
+				event := <-events
 				log.Infof("%s %v", event.Type, event.Object)
 				if event.Type == "" {
 					log.Infof("stream closed, restarting after delay")
@@ -59,6 +61,3 @@ func main() {
 		time.Sleep(time.Second * 2)
 	}
 }
-
-
-

--- a/cmd/namespace-watcher/one_ns_watcher.go
+++ b/cmd/namespace-watcher/one_ns_watcher.go
@@ -18,14 +18,16 @@ limitations under the License.
 package main
 
 import (
-	//	"k8s.io/client-go/kubernetes/typed/core/v1"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"k8s.io/client-go/kubernetes"
-	log "github.com/sirupsen/logrus"
-	"github.com/platform9/decco/pkg/k8sutil"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	scheme "k8s.io/client-go/kubernetes/scheme"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	scheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	//	"k8s.io/client-go/kubernetes/typed/core/v1"
+	"github.com/platform9/decco/pkg/k8sutil"
 )
 
 func main() {
@@ -45,7 +47,7 @@ func main() {
 		} else {
 			events := watcher.ResultChan()
 			for {
-				event := <- events
+				event := <-events
 				log.Infof("%s %v", event.Type, event.Object)
 				if event.Type == "" {
 					log.Infof("stream closed, restarting after delay")
@@ -56,6 +58,3 @@ func main() {
 		time.Sleep(time.Second * 2)
 	}
 }
-
-
-

--- a/cmd/namespaces-watcher/ns_watcher.go
+++ b/cmd/namespaces-watcher/ns_watcher.go
@@ -18,13 +18,15 @@ limitations under the License.
 package main
 
 import (
-	//	"k8s.io/client-go/kubernetes/typed/core/v1"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"k8s.io/client-go/kubernetes"
-	log "github.com/sirupsen/logrus"
-	"github.com/platform9/decco/pkg/k8sutil"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	//	"k8s.io/client-go/kubernetes/typed/core/v1"
+	"github.com/platform9/decco/pkg/k8sutil"
 )
 
 func main() {
@@ -38,7 +40,7 @@ func main() {
 		} else {
 			events := watcher.ResultChan()
 			for {
-				event := <- events
+				event := <-events
 				log.Infof("%s %v", event.Type, event.Object)
 				if event.Type == "" {
 					log.Infof("stream closed, restarting after delay")

--- a/cmd/operator/operator_main.go
+++ b/cmd/operator/operator_main.go
@@ -18,13 +18,15 @@ limitations under the License.
 package main
 
 import (
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	log "github.com/sirupsen/logrus"
-	"k8s.io/client-go/kubernetes"
-	"github.com/platform9/decco/pkg/k8sutil"
-	"github.com/platform9/decco/pkg/spacecontroller"
 	"os"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	"github.com/platform9/decco/pkg/k8sutil"
+	"github.com/platform9/decco/pkg/spacecontroller"
 )
 
 func main() {
@@ -51,4 +53,3 @@ func main() {
 		}
 	}
 }
-

--- a/pkg/app/gc.go
+++ b/pkg/app/gc.go
@@ -2,9 +2,10 @@ package app
 
 import (
 	"context"
+
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"github.com/sirupsen/logrus"
 )
 
 func Collect(kubeApi kubernetes.Interface,
@@ -70,7 +71,7 @@ func collectServices(kubeApi kubernetes.Interface,
 	for _, svc := range svcs.Items {
 		labels := svc.Labels
 		appName, ok := labels["decco-app"]
-		if ! ok {
+		if !ok {
 			log.Warnf("service %s has no decco-app label", svc.Name)
 			continue
 		}

--- a/pkg/appspec/app_rsc.go
+++ b/pkg/appspec/app_rsc.go
@@ -17,6 +17,7 @@ package appspec
 import (
 	"encoding/json"
 	"errors"
+
 	"k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,10 +25,10 @@ import (
 )
 
 var (
-	ErrInvalidPort             = errors.New("spec: endpoint has invalid port value")
-	ErrInvalidUrlPath          = errors.New("spec: invalid url path")
+	ErrInvalidPort                    = errors.New("spec: endpoint has invalid port value")
+	ErrInvalidUrlPath                 = errors.New("spec: invalid url path")
 	ErrBothUrlPathAndDisableTcpVerify = errors.New("spec: url path and disable tcp verify cannot both be set")
-	ErrNoTcpCert               = errors.New("spec: space does not support TCP apps because cert info missing")
+	ErrNoTcpCert                      = errors.New("spec: space does not support TCP apps because cert info missing")
 )
 
 // AppList is a list of apps.
@@ -35,7 +36,7 @@ type AppList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata
 	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
-	metav1.ListMeta                  `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []App `json:"items"`
 }
 
@@ -83,33 +84,33 @@ func (c App) GetObjectKind() schema.ObjectKind {
 //                    specified space. The constructed fqdn is internal and is:
 //                    ${Endpoint}.${SpaceName}.svc.cluster.local
 type TlsEgress struct {
-	Fqdn string                `json:"fqdn"`
-	Endpoint string            `json:"endpoint"`
-	SpaceName string           `json:"spaceName"`
-	TargetPort int32           `json:"targetPort"`
-	LocalPort int32            `json:"localPort"`   // local listening port
-	CertAndCaSecretName string `json:"certAndCaSecretName"`
-	SpringBoardDelaySeconds int32 `json:"springBoardDelaySeconds"`
-	DisableServerCertVerification bool `json:"disableServerCertVerification"`
+	Fqdn                          string `json:"fqdn"`
+	Endpoint                      string `json:"endpoint"`
+	SpaceName                     string `json:"spaceName"`
+	TargetPort                    int32  `json:"targetPort"`
+	LocalPort                     int32  `json:"localPort"` // local listening port
+	CertAndCaSecretName           string `json:"certAndCaSecretName"`
+	SpringBoardDelaySeconds       int32  `json:"springBoardDelaySeconds"`
+	DisableServerCertVerification bool   `json:"disableServerCertVerification"`
 }
 
 type AppSpec struct {
-	PodSpec         v1.PodSpec `json:"pod"`
-	InitialReplicas int32 `json:"initialReplicas"`
-	Egresses        []TlsEgress
-	RunAsJob        bool `json:"runAsJob"`
-	JobBackoffLimit int32 `json:"jobBackoffLimit"`
-	Endpoints       []EndpointSpec
+	PodSpec                 v1.PodSpec `json:"pod"`
+	InitialReplicas         int32      `json:"initialReplicas"`
+	Egresses                []TlsEgress
+	RunAsJob                bool  `json:"runAsJob"`
+	JobBackoffLimit         int32 `json:"jobBackoffLimit"`
+	Endpoints               []EndpointSpec
 	FirstEndpointListenPort int32
-	Permissions     []rbacv1.PolicyRule
-	DomainEnvVarName string `json:"domainEnvVarName"`
+	Permissions             []rbacv1.PolicyRule
+	DomainEnvVarName        string `json:"domainEnvVarName"`
 }
 
 type EndpointSpec struct {
-	Name                string
-	Port                int32
-	IsMetricsEndpoint   bool  // optional, TCP only, no SNI / TLS / stunnel
-	TlsListenPort       int32 // optional, defaults to 443 + endpoint index
+	Name              string
+	Port              int32
+	IsMetricsEndpoint bool  // optional, TCP only, no SNI / TLS / stunnel
+	TlsListenPort     int32 // optional, defaults to 443 + endpoint index
 	// optional Cert and CA if don't want to use default one for the space
 	CertAndCaSecretName string `json:"certAndCaSecretName"`
 	CreateClearTextSvc  bool   `json:"createClearTextSvc"`
@@ -118,20 +119,20 @@ type EndpointSpec struct {
 	// RewritePath value is interpreted as follows:
 	// empty: the path is forwarded unmodified
 	// non-empty: the specified HttpPath prefix is replaced with the value
-	HttpPath             string `json:"httpPath"`
-	RewritePath          string `json:"rewritePath"`
-	HttpLocalhostOnly bool `json:"httpLocalhostOnly"`
+	HttpPath          string `json:"httpPath"`
+	RewritePath       string `json:"rewritePath"`
+	HttpLocalhostOnly bool   `json:"httpLocalhostOnly"`
 
 	// The following only apply to tcp endpoints (httpPath empty)
-	CreateDnsRecord     bool   `json:"createDnsRecord"`
-	DisableTlsTermination bool `json:"disableTlsTermination"`
+	CreateDnsRecord                 bool   `json:"createDnsRecord"`
+	DisableTlsTermination           bool   `json:"disableTlsTermination"`
 	DisableTcpClientTlsVerification bool   `json:"disableTcpClientTlsVerification"`
-	SniHostname string   `json:"sniHostname"` // optional SNI hostname override
+	SniHostname                     string `json:"sniHostname"` // optional SNI hostname override
 	// Optional name suffix to append to server name for SNI routing purposes.
 	// For e.g., if endpoint name is "foo", space domain name is "bar.com",
 	// and nameSuffix is ".v0", then the SNI routing name becomes:
 	// foo.v0.bar.com
-	TcpHostnameSuffix           string `json:"tcpHostnameSuffix"`
+	TcpHostnameSuffix string `json:"tcpHostnameSuffix"`
 
 	// Optional ingress resource annotations
 	AdditionalIngressAnnotations map[string]string `json:"additionalIngressAnnotations,omitempty"`
@@ -164,15 +165,15 @@ type AppPhase string
 
 const (
 	AppPhaseNone     AppPhase = ""
-	AppPhaseCreating                     = "Creating"
-	AppPhaseActive                       = "Active"
-	AppPhaseFailed                       = "Failed"
+	AppPhaseCreating          = "Creating"
+	AppPhaseActive            = "Active"
+	AppPhaseFailed            = "Failed"
 )
 
 type AppCondition struct {
-	Type AppConditionType `json:"type"`
-	Reason string `json:"reason"`
-	TransitionTime string `json:"transitionTime"`
+	Type           AppConditionType `json:"type"`
+	Reason         string           `json:"reason"`
+	TransitionTime string           `json:"transitionTime"`
 }
 
 type AppConditionType string
@@ -180,7 +181,7 @@ type AppConditionType string
 type AppStatus struct {
 	// Phase is the app running phase
 	Phase  AppPhase `json:"phase"`
-	Reason string       `json:"reason"`
+	Reason string   `json:"reason"`
 }
 
 func (cs AppStatus) Copy() AppStatus {
@@ -210,4 +211,3 @@ func (cs *AppStatus) SetPhase(p AppPhase) {
 func (cs *AppStatus) SetReason(r string) {
 	cs.Reason = r
 }
-

--- a/pkg/appspec/registration.go
+++ b/pkg/appspec/registration.go
@@ -30,9 +30,9 @@ const (
 )
 
 var (
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	Scheme = runtime.NewScheme()
-	Codecs = serializer.NewCodecFactory(Scheme)
+	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
+	Scheme             = runtime.NewScheme()
+	Codecs             = serializer.NewCodecFactory(Scheme)
 	SchemeGroupVersion = schema.GroupVersion{Group: groupName, Version: "v1beta2"}
 	CRDName            = CRDResourcePlural + "." + groupName
 )

--- a/pkg/client/cust_resource.go
+++ b/pkg/client/cust_resource.go
@@ -2,12 +2,13 @@ package client
 
 import (
 	"fmt"
-	"github.com/platform9/decco/pkg/appspec"
-	"github.com/platform9/decco/pkg/spec"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
-)
 
+	"github.com/platform9/decco/pkg/appspec"
+	"github.com/platform9/decco/pkg/spec"
+)
 
 // TODO: make this private so that we don't expose RESTClient once operator code uses this client instead of REST calls
 func New(cfg *rest.Config) (*rest.RESTClient, error) {

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -1,20 +1,21 @@
 package dns
 
 import (
-	"github.com/sirupsen/logrus"
-	_ "k8s.io/federation/pkg/dnsprovider/providers/aws/route53"
-	"k8s.io/federation/pkg/dnsprovider"
-	"k8s.io/federation/pkg/dnsprovider/rrstype"
-	"os"
 	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/federation/pkg/dnsprovider"
+	_ "k8s.io/federation/pkg/dnsprovider/providers/aws/route53"
+	"k8s.io/federation/pkg/dnsprovider/rrstype"
 )
 
 var (
 	dnsProvider dnsprovider.Interface
-	log = logrus.WithField("pkg","dns")
+	log         = logrus.WithField("pkg", "dns")
 )
 
-func init () {
+func init() {
 	dnsProviderName := os.Getenv("DNS_PROVIDER_NAME")
 	if len(dnsProviderName) > 0 {
 		var err error
@@ -58,7 +59,7 @@ func UpdateRecord(domainName string, name string, ipOrHostname string,
 				if len(rrSetList) == 0 {
 					log.Infof("not deleting DNS record because rrSetList empty")
 					return nil
-				} else{
+				} else {
 					changeSet.Remove(rrSetList[0])
 				}
 			} else {
@@ -66,7 +67,7 @@ func UpdateRecord(domainName string, name string, ipOrHostname string,
 				if isHostname {
 					rscType = rrstype.CNAME
 				}
-				rrSet := rrSets.New(rrName, []string{ipOrHostname},180, rscType)
+				rrSet := rrSets.New(rrName, []string{ipOrHostname}, 180, rscType)
 				if len(rrSetList) == 0 {
 					action = "creation"
 				} else {
@@ -87,4 +88,3 @@ func UpdateRecord(domainName string, name string, ipOrHostname string,
 	}
 	return fmt.Errorf("failed to find DNS zone %s", zoneName)
 }
-

--- a/pkg/k8sutil/app_rsc_def.go
+++ b/pkg/k8sutil/app_rsc_def.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd-operator/pkg/util/retryutil"
+
 	spec "github.com/platform9/decco/pkg/appspec"
 
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"

--- a/pkg/k8sutil/cust_rsc_def.go
+++ b/pkg/k8sutil/cust_rsc_def.go
@@ -21,8 +21,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/platform9/decco/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/retryutil"
+
+	"github.com/platform9/decco/pkg/spec"
 
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"

--- a/pkg/k8sutil/ingress.go
+++ b/pkg/k8sutil/ingress.go
@@ -2,12 +2,12 @@ package k8sutil
 
 import (
 	"context"
-	"k8s.io/client-go/kubernetes"
+
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
 )
-
 
 func CreateHttpIngress(
 	kubeApi kubernetes.Interface,
@@ -28,7 +28,7 @@ func CreateHttpIngress(
 	annotations := make(map[string]string)
 	// Copy over additional annotations.
 	// Note: this works even if additionalAnnotations is nil
-	for key, val := range additionalAnnotations{
+	for key, val := range additionalAnnotations {
 		annotations[key] = val
 	}
 	// temporary hack to work around nginx-to-stunnel timeouts during heavy load
@@ -43,15 +43,15 @@ func CreateHttpIngress(
 	if encryptHttp {
 		annotations["nginx.ingress.kubernetes.io/secure-backends"] = "true"
 	}
-	ruleValue := v1beta1.IngressRuleValue {
+	ruleValue := v1beta1.IngressRuleValue{
 		HTTP: &v1beta1.HTTPIngressRuleValue{
-			Paths: []v1beta1.HTTPIngressPath {
+			Paths: []v1beta1.HTTPIngressPath{
 				{
 					Path: path,
 					Backend: v1beta1.IngressBackend{
 						ServiceName: svcName,
-						ServicePort: intstr.IntOrString {
-							Type: intstr.Int,
+						ServicePort: intstr.IntOrString{
+							Type:   intstr.Int,
 							IntVal: svcPort,
 						},
 					},
@@ -62,17 +62,17 @@ func CreateHttpIngress(
 	tls := []v1beta1.IngressTLS{}
 	rules := []v1beta1.IngressRule{
 		{
-			Host: "localhost",
+			Host:             "localhost",
 			IngressRuleValue: ruleValue,
 		},
 	}
 	if !localhostOnly {
 		rules = append(rules, v1beta1.IngressRule{
-			Host: hostName,
+			Host:             hostName,
 			IngressRuleValue: ruleValue,
 		})
 		tls = append(tls, v1beta1.IngressTLS{
-			Hosts: []string {
+			Hosts: []string{
 				hostName,
 			},
 			SecretName: secretName,
@@ -80,13 +80,13 @@ func CreateHttpIngress(
 	}
 	ing := v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: labels,
+			Name:        name,
+			Labels:      labels,
 			Annotations: annotations,
 		},
 		Spec: v1beta1.IngressSpec{
 			Rules: rules,
-			TLS: tls,
+			TLS:   tls,
 		},
 	}
 	ctx := context.Background()

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -1,12 +1,13 @@
 package k8sutil
 
 import (
+	"flag"
+	"os"
+	"path/filepath"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
-	"flag"
-	"path/filepath"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var kubeconfig *string

--- a/pkg/k8sutil/misc.go
+++ b/pkg/k8sutil/misc.go
@@ -3,8 +3,9 @@ package k8sutil
 import (
 	"context"
 	"fmt"
-	"k8s.io/client-go/kubernetes"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 func GetTcpIngressIpOrHostname(kubeApi kubernetes.Interface) (string, bool, error) {
@@ -14,7 +15,7 @@ func GetTcpIngressIpOrHostname(kubeApi kubernetes.Interface) (string, bool, erro
 	if err != nil {
 		return "", false, fmt.Errorf("failed to get k8sniff service: %s", err)
 	}
-	lbIngresses := svc.Status.LoadBalancer.Ingress;
+	lbIngresses := svc.Status.LoadBalancer.Ingress
 	if len(lbIngresses) == 0 {
 		return "", false, fmt.Errorf("k8sniff service has no LB ingresses")
 	}
@@ -28,4 +29,3 @@ func GetTcpIngressIpOrHostname(kubeApi kubernetes.Interface) (string, bool, erro
 	}
 	return "", false, fmt.Errorf("k8sniff service has no IP or hostname")
 }
-

--- a/pkg/k8sutil/stunnel.go
+++ b/pkg/k8sutil/stunnel.go
@@ -3,6 +3,7 @@ package k8sutil
 import (
 	"fmt"
 	"os"
+
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -22,48 +23,48 @@ func stunnelEnvVars(
 	index int,
 ) []v1.EnvVar {
 
-	springboardListenPort := fmt.Sprintf("%d", 6789 + index)
-	stunnelEnv := []v1.EnvVar {
+	springboardListenPort := fmt.Sprintf("%d", 6789+index)
+	stunnelEnv := []v1.EnvVar{
 		{
-			Name: "STUNNEL_VERIFY_CHAIN",
+			Name:  "STUNNEL_VERIFY_CHAIN",
 			Value: verifyChain,
 		},
 		{
-			Name: "STUNNEL_ACCEPT_PORT",
+			Name:  "STUNNEL_ACCEPT_PORT",
 			Value: fmt.Sprintf("%d", listenPort),
 		},
 		{
-			Name: "STUNNEL_CONNECT",
+			Name:  "STUNNEL_CONNECT",
 			Value: destHostAndPort,
 		},
 		{
-			Name: "SPRINGBOARD_LISTEN_PORT",
+			Name:  "SPRINGBOARD_LISTEN_PORT",
 			Value: springboardListenPort,
 		},
 		{
-			Name: "STUNNEL_CERT_FILE",
+			Name:  "STUNNEL_CERT_FILE",
 			Value: "/etc/stunnel/certs/tls.crt",
 		},
 		{
-			Name: "STUNNEL_KEY_FILE",
+			Name:  "STUNNEL_KEY_FILE",
 			Value: "/etc/stunnel/certs/tls.key",
 		},
 	}
 	if isClientMode {
 		stunnelEnv = append(stunnelEnv, v1.EnvVar{
-			Name: "STUNNEL_CLIENT_MODE",
+			Name:  "STUNNEL_CLIENT_MODE",
 			Value: "yes",
 		})
 		if clientModeSpringBoardDelaySeconds > 0 {
 			stunnelEnv = append(stunnelEnv, v1.EnvVar{
-				Name: "SPRINGBOARD_DELAY_SECONDS",
+				Name:  "SPRINGBOARD_DELAY_SECONDS",
 				Value: fmt.Sprintf("%d", clientModeSpringBoardDelaySeconds),
 			})
 		}
 	}
 	if checkHost != "" {
 		stunnelEnv = append(stunnelEnv, v1.EnvVar{
-			Name: "STUNNEL_CHECKHOST_LINE",
+			Name:  "STUNNEL_CHECKHOST_LINE",
 			Value: fmt.Sprintf("checkHost=%s", checkHost),
 		})
 	}
@@ -73,11 +74,11 @@ func stunnelEnvVars(
 		// There is no CA for client certificate verification (for now).
 		stunnelEnv = append(stunnelEnv,
 			v1.EnvVar{
-				Name: "STUNNEL_CERT_FILE",
+				Name:  "STUNNEL_CERT_FILE",
 				Value: "/etc/stunnel/certs/tls.crt",
 			},
 			v1.EnvVar{
-				Name: "STUNNEL_KEY_FILE",
+				Name:  "STUNNEL_KEY_FILE",
 				Value: "/etc/stunnel/certs/tls.key",
 			},
 		)
@@ -126,19 +127,19 @@ func InsertStunnel(
 	limits := v1.ResourceList{}
 	if limitCPU != "" {
 		limits["cpu"] = resource.MustParse(limitCPU)
-        }
+	}
 	if limitMem != "" {
 		limits["memory"] = resource.MustParse(limitMem)
 	}
-        resourceRequirements := v1.ResourceRequirements{
+	resourceRequirements := v1.ResourceRequirements{
 		Requests: v1.ResourceList{
 			"cpu":    resource.MustParse(getEnvVarWithDefault("STUNNEL_REQUEST_CPU", "5m")),
 			"memory": resource.MustParse(getEnvVarWithDefault("STUNNEL_REQUEST_MEMORY", "10Mi")),
 		},
 		Limits: limits,
 	}
-        containers = append(containers, v1.Container{
-		Name: containerName,
+	containers = append(containers, v1.Container{
+		Name:  containerName,
 		Image: "platform9/springboard-stunnel:1.0.0-000",
 		Ports: []v1.ContainerPort{
 			{
@@ -148,8 +149,8 @@ func InsertStunnel(
 		Env: stunnelEnv,
 		VolumeMounts: []v1.VolumeMount{
 			{
-				Name: volumeName,
-				ReadOnly: true,
+				Name:      volumeName,
+				ReadOnly:  true,
 				MountPath: "/etc/stunnel/certs",
 			},
 		},
@@ -161,9 +162,9 @@ func InsertStunnel(
 // Get env variables and default to the defaultVal if none found
 // in the process environment
 func getEnvVarWithDefault(key string, defaultVal string) string {
-    val := os.Getenv(key)
-    if val == "" {
-        return defaultVal
-    }
-    return val
+	val := os.Getenv(key)
+	if val == "" {
+		return defaultVal
+	}
+	return val
 }

--- a/pkg/misc/misc.go
+++ b/pkg/misc/misc.go
@@ -1,20 +1,18 @@
 package misc
 
 import (
-	"github.com/cenkalti/backoff"
 	"time"
+
+	"github.com/cenkalti/backoff"
 )
 
 func DefaultBackoff() backoff.BackOff {
 	return &backoff.ExponentialBackOff{
-		InitialInterval: time.Second * 3,
+		InitialInterval:     time.Second * 3,
 		RandomizationFactor: 0.0,
-		Multiplier: 2,
-		MaxInterval: time.Second * 60,
-		MaxElapsedTime: time.Second * 300,
-		Clock: backoff.SystemClock,
+		Multiplier:          2,
+		MaxInterval:         time.Second * 60,
+		MaxElapsedTime:      time.Second * 300,
+		Clock:               backoff.SystemClock,
 	}
 }
-
-
-

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -1,10 +1,11 @@
 package slack
 
 import (
-	"github.com/sirupsen/logrus"
-	"fmt"
 	"bytes"
+	"fmt"
 	"net/http"
+
+	"github.com/sirupsen/logrus"
 )
 
 func PostBestEffort(url string, msg string, log *logrus.Entry) {

--- a/pkg/space/gc.go
+++ b/pkg/space/gc.go
@@ -2,6 +2,7 @@ package space
 
 import (
 	"context"
+
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/spacecontroller/spacecontroller.go
+++ b/pkg/spacecontroller/spacecontroller.go
@@ -16,20 +16,22 @@ package spacecontroller
 
 import (
 	"encoding/json"
-	"github.com/sirupsen/logrus"
-	"github.com/platform9/decco/pkg/k8sutil"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	restclient "k8s.io/client-go/rest"
-	kwatch "k8s.io/apimachinery/pkg/watch"
 	"fmt"
-	"k8s.io/client-go/kubernetes"
-	"github.com/platform9/decco/pkg/space"
 	"net/http"
-	"github.com/platform9/decco/pkg/spec"
-	"github.com/platform9/decco/pkg/appcontroller"
-	"github.com/platform9/decco/pkg/watcher"
-	"k8s.io/client-go/rest"
 	"sync"
+
+	"github.com/sirupsen/logrus"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	kwatch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	restclient "k8s.io/client-go/rest"
+
+	"github.com/platform9/decco/pkg/appcontroller"
+	"github.com/platform9/decco/pkg/k8sutil"
+	"github.com/platform9/decco/pkg/space"
+	"github.com/platform9/decco/pkg/spec"
+	"github.com/platform9/decco/pkg/watcher"
 )
 
 func init() {
@@ -40,18 +42,18 @@ func init() {
 }
 
 type Controller struct {
-	log *logrus.Entry
-	apiHost string
-	extensionsApi apiextensionsclient.Interface
-	kubeApi kubernetes.Interface
-	waitApps sync.WaitGroup
+	log                      *logrus.Entry
+	apiHost                  string
+	extensionsApi            apiextensionsclient.Interface
+	kubeApi                  kubernetes.Interface
+	waitApps                 sync.WaitGroup
 	garbageCollectNamespaces bool
 }
 
 type SpaceInfo struct {
-	spc *space.SpaceRuntime
-	appCtrl    *appcontroller.Controller
-	log *logrus.Entry
+	spc     *space.SpaceRuntime
+	appCtrl *appcontroller.Controller
+	log     *logrus.Entry
 }
 
 // ----------------------------------------------------------------------------
@@ -62,7 +64,7 @@ func (spcInfo *SpaceInfo) Name() string {
 
 // ----------------------------------------------------------------------------
 
-func (spcInfo *SpaceInfo) Delete()  {
+func (spcInfo *SpaceInfo) Delete() {
 	nsDeleted := spcInfo.spc.Delete()
 	if !nsDeleted {
 		// An active space resource might have no associated namespace if for
@@ -87,7 +89,7 @@ func (spcInfo *SpaceInfo) Stop() {
 
 // ----------------------------------------------------------------------------
 
-func (spcInfo *SpaceInfo) Update(item watcher.Item)  {
+func (spcInfo *SpaceInfo) Update(item watcher.Item) {
 	wrapped := item.(*spaceWrapper)
 	spc := wrapped.space
 	spcInfo.spc.Update(*spc)
@@ -102,10 +104,10 @@ func New(
 	logger := logrus.WithField("pkg", "spacecontroller")
 	logger.Logger.SetLevel(logrus.DebugLevel)
 	return &Controller{
-		log: logger,
-		apiHost: clustConfig.Host,
+		log:           logger,
+		apiHost:       clustConfig.Host,
 		extensionsApi: k8sutil.MustNewKubeExtClient(),
-		kubeApi: kubeApi,
+		kubeApi:       kubeApi,
 	}
 }
 
@@ -185,9 +187,9 @@ func (c *Controller) InitItem(item watcher.Item) watcher.ManagedItem {
 			spc.Name)
 	}
 	return &SpaceInfo{
-		spc: newSpaceRt,
+		spc:     newSpaceRt,
 		appCtrl: appCtrl,
-		log: c.log.WithField("spaceInfo", spc.Name),
+		log:     c.log.WithField("spaceInfo", spc.Name),
 	}
 }
 

--- a/pkg/spec/registration.go
+++ b/pkg/spec/registration.go
@@ -30,9 +30,9 @@ const (
 )
 
 var (
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	Scheme = runtime.NewScheme()
-	Codecs = serializer.NewCodecFactory(Scheme)
+	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
+	Scheme             = runtime.NewScheme()
+	Codecs             = serializer.NewCodecFactory(Scheme)
 	SchemeGroupVersion = schema.GroupVersion{Group: groupName, Version: "v1beta2"}
 	CRDName            = CRDResourcePlural + "." + groupName
 )
@@ -49,4 +49,3 @@ func addKnownTypes(s *runtime.Scheme) error {
 func init() {
 	utilruntime.Must(SchemeBuilder.AddToScheme(Scheme))
 }
-

--- a/pkg/spec/space_rsc.go
+++ b/pkg/spec/space_rsc.go
@@ -17,9 +17,10 @@ package spec
 import (
 	"encoding/json"
 	"errors"
+
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 const (
@@ -27,9 +28,9 @@ const (
 )
 
 var (
-	ErrDomainNameMissing = errors.New("spec: missing domain name")
+	ErrDomainNameMissing         = errors.New("spec: missing domain name")
 	ErrHttpCertSecretNameMissing = errors.New("spec: missing certificate secret name")
-	ErrInvalidProjectName = errors.New("spec: invalid project name")
+	ErrInvalidProjectName        = errors.New("spec: invalid project name")
 )
 
 // SpaceList is a list of spaces.
@@ -37,7 +38,7 @@ type SpaceList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata
 	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
-	metav1.ListMeta                  `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Space `json:"items"`
 }
 
@@ -73,20 +74,20 @@ type SpacePermissions struct {
 }
 
 type SpaceSpec struct {
-	DomainName             string `json:"domainName"`
-	Project                string `json:"project"`
-	HttpCertSecretName     string `json:"httpCertSecretName"`
-	TcpCertAndCaSecretName string `json:"tcpCertAndCaSecretName"`
-	EncryptHttp            bool   `json:"encryptHttp"`
-	DeleteHttpCertSecretAfterCopy bool   `json:"deleteHttpCertSecretAfterCopy"`
-	DeleteTcpCertAndCaSecretAfterCopy bool   `json:"deleteTcpCertAndCaSecretAfterCopy"`
-	DisablePrivateIngressController bool `json:"disablePrivateIngressController"`
-	VerboseIngressControllerLogging bool `json:"verboseIngressControllerLogging"`
+	DomainName                           string   `json:"domainName"`
+	Project                              string   `json:"project"`
+	HttpCertSecretName                   string   `json:"httpCertSecretName"`
+	TcpCertAndCaSecretName               string   `json:"tcpCertAndCaSecretName"`
+	EncryptHttp                          bool     `json:"encryptHttp"`
+	DeleteHttpCertSecretAfterCopy        bool     `json:"deleteHttpCertSecretAfterCopy"`
+	DeleteTcpCertAndCaSecretAfterCopy    bool     `json:"deleteTcpCertAndCaSecretAfterCopy"`
+	DisablePrivateIngressController      bool     `json:"disablePrivateIngressController"`
+	VerboseIngressControllerLogging      bool     `json:"verboseIngressControllerLogging"`
 	PrivateIngressControllerTcpEndpoints []string `json:"privateIngressControllerTcpEndpoints"`
 	// Optional suffix to append to host names of private ingress controller's tcp endpoints
-	PrivateIngressControllerTcpHostnameSuffix string `json:"privateIngressControllerTcpHostnameSuffix"`
-	Permissions *SpacePermissions `json:permissions`
-	CreateDefaultHttpDeploymentAndIngress bool `json:createDefaultHttpDeploymentAndIngress`
+	PrivateIngressControllerTcpHostnameSuffix string            `json:"privateIngressControllerTcpHostnameSuffix"`
+	Permissions                               *SpacePermissions `json:permissions`
+	CreateDefaultHttpDeploymentAndIngress     bool              `json:createDefaultHttpDeploymentAndIngress`
 }
 
 func (c *SpaceSpec) Validate() error {
@@ -122,15 +123,15 @@ type SpacePhase string
 
 const (
 	SpacePhaseNone     SpacePhase = ""
-	SpacePhaseCreating                     = "Creating"
-	SpacePhaseActive                       = "Active"
-	SpacePhaseFailed                       = "Failed"
+	SpacePhaseCreating            = "Creating"
+	SpacePhaseActive              = "Active"
+	SpacePhaseFailed              = "Failed"
 )
 
 type SpaceCondition struct {
-	Type SpaceConditionType `json:"type"`
-	Reason string `json:"reason"`
-	TransitionTime string `json:"transitionTime"`
+	Type           SpaceConditionType `json:"type"`
+	Reason         string             `json:"reason"`
+	TransitionTime string             `json:"transitionTime"`
 }
 
 type SpaceConditionType string
@@ -138,7 +139,7 @@ type SpaceConditionType string
 type SpaceStatus struct {
 	// Phase is the Space running phase
 	Phase  SpacePhase `json:"phase"`
-	Reason string       `json:"reason"`
+	Reason string     `json:"reason"`
 }
 
 func (cs SpaceStatus) Copy() SpaceStatus {
@@ -168,4 +169,3 @@ func (cs *SpaceStatus) SetPhase(p SpacePhase) {
 func (cs *SpaceStatus) SetReason(r string) {
 	cs.Reason = r
 }
-


### PR DESCRIPTION
Part of the Decco v2 work: this PR formats the Go code using gofmt and goimports (for rearranging imports), to avoid cluttering the future changes with formatting changes.