### PR TITLE
make stunnel base image tag configurable, start using TCP keepalive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ IMAGE_TAG ?= $(VERSION)-$(BUILD_ID)
 FULL_TAG := $(REPO_TAG):$(IMAGE_TAG)
 TAG_FILE := $(BUILD_DIR)/container-full-tag
 
+STUNNEL_CONTAINER_TAG ?= platform9/stunnel:5.56-102
 SPRINGBOARD_REPO_TAG ?= platform9/$(SPRINGBOARD_IMAGE_NAME)
 SPRINGBOARD_FULL_TAG := $(SPRINGBOARD_REPO_TAG):$(IMAGE_TAG)
 
@@ -68,6 +69,7 @@ $(SPRINGBOARD_EXE): | $(SPRINGBOARD_STAGE_DIR)
 
 $(SPRINGBOARD_IMAGE_MARKER): $(SPRINGBOARD_EXE)
 	cp -f $(SRC_DIR)/support/stunnel-instrumented-with-springboard/* $(SPRINGBOARD_STAGE_DIR)
+	sed -i 's|__STUNNEL_CONTAINER_TAG__|$(STUNNEL_CONTAINER_TAG)|g' $(SPRINGBOARD_STAGE_DIR)/Dockerfile
 	docker build --tag $(SPRINGBOARD_FULL_TAG) $(SPRINGBOARD_STAGE_DIR)
 	touch $@
 
@@ -79,6 +81,9 @@ springboard-push: $(SPRINGBOARD_IMAGE_MARKER)
 		docker push $(SPRINGBOARD_FULL_TAG) && docker logout))
 	docker rmi $(SPRINGBOARD_FULL_TAG)
 	rm -f $(SPRINGBOARD_IMAGE_MARKER)
+
+springboard-clean:
+	rm -rf $(SPRINGBOARD_STAGE_DIR)
 
 springboard:
 	cd $(SRC_DIR)/cmd/springboard && go build -o $(SRC_DIR)/support/stunnel-with-springboard/springboard

--- a/pkg/k8sutil/stunnel.go
+++ b/pkg/k8sutil/stunnel.go
@@ -8,7 +8,17 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+var springboardStunnelImageTag string
 const TlsPort = 443
+
+// -----------------------------------------------------------------------------
+
+func init() {
+	springboardStunnelImageTag = os.Getenv("SPRINGBOARD_STUNNEL_IMAGE_TAG")
+	if springboardStunnelImageTag == "" {
+		springboardStunnelImageTag = "platform9/springboard-stunnel:1.0.0-002"
+	}
+}
 
 // -----------------------------------------------------------------------------
 
@@ -107,10 +117,6 @@ func InsertStunnel(
 		checkHost, isNginxIngressStyleCertSecret, isClientMode,
 		clientModeSpringBoardDelaySeconds, index)
 
-	// Reduce TCP keep-alive (net.ipv4.tcp_keepalive_time) idle interval to
-	// 75 seconds, the Linux system default is 7200, or 2 hours!
-	stunnelEnv = append(stunnelEnv, v1.EnvVar{Name:  "KEEPIDLE", Value: "75"})
-
 	volumeName := fmt.Sprintf("%s-certs", containerName)
 	volumes = append(volumes, v1.Volume{
 		Name: volumeName,
@@ -144,7 +150,7 @@ func InsertStunnel(
 	}
 	containers = append(containers, v1.Container{
 		Name:  containerName,
-		Image: "platform9/springboard-stunnel:1.0.0-001",
+		Image: springboardStunnelImageTag,
 		Ports: []v1.ContainerPort{
 			{
 				ContainerPort: listenPort,

--- a/pkg/k8sutil/stunnel.go
+++ b/pkg/k8sutil/stunnel.go
@@ -107,6 +107,10 @@ func InsertStunnel(
 		checkHost, isNginxIngressStyleCertSecret, isClientMode,
 		clientModeSpringBoardDelaySeconds, index)
 
+	// Reduce TCP keep-alive (net.ipv4.tcp_keepalive_time) idle interval to
+	// 75 seconds, the Linux system default is 7200, or 2 hours!
+	stunnelEnv = append(stunnelEnv, v1.EnvVar{Name:  "KEEPIDLE", Value: "75"})
+
 	volumeName := fmt.Sprintf("%s-certs", containerName)
 	volumes = append(volumes, v1.Volume{
 		Name: volumeName,
@@ -140,7 +144,7 @@ func InsertStunnel(
 	}
 	containers = append(containers, v1.Container{
 		Name:  containerName,
-		Image: "platform9/springboard-stunnel:1.0.0-000",
+		Image: "platform9/springboard-stunnel:1.0.0-001",
 		Ports: []v1.ContainerPort{
 			{
 				ContainerPort: listenPort,

--- a/support/stunnel-instrumented-with-springboard/Dockerfile
+++ b/support/stunnel-instrumented-with-springboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM platform9systems/stunnel:instrumented
+FROM __STUNNEL_CONTAINER_TAG__
 ADD stunnel.sh /usr/local/bin/
 ADD stunnel.conf.template /etc/stunnel/
 ADD springboard /usr/local/bin/

--- a/support/stunnel-instrumented-with-springboard/Dockerfile
+++ b/support/stunnel-instrumented-with-springboard/Dockerfile
@@ -3,4 +3,17 @@ ADD stunnel.sh /usr/local/bin/
 ADD stunnel.conf.template /etc/stunnel/
 ADD springboard /usr/local/bin/
 RUN apt-get -y update && apt-get -y install gettext-base
+
+
+# The stunnel container is equipped with a system-wide libkeepalive, which
+# enables TCP keepalive for all sockets by default. It allows the following
+# systctl parameters to be configured via environment variables:
+#   env               sysctl
+#   KEEPCNT     <=>   net.ipv4.tcp_keepalive_probes
+#   KEEPIDLE    <=>   net.ipv4.tcp_keepalive_time
+#   KEEPINTVL   <=>   net.ipv4.tcp_keepalive_intvl
+# Reduce the idle period (net.ipv4.tcp_keepalive_time) to 75 seconds
+# the Linux system default is 7200, or 2 hours, which is too long to be useful.
+ENV KEEPIDLE 75
+
 ENTRYPOINT ["/usr/local/bin/springboard", "/bin/bash", "/usr/local/bin/stunnel.sh"]

--- a/support/stunnel-instrumented-with-springboard/Dockerfile
+++ b/support/stunnel-instrumented-with-springboard/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get -y update && apt-get -y install gettext-base
 #   KEEPCNT     <=>   net.ipv4.tcp_keepalive_probes
 #   KEEPIDLE    <=>   net.ipv4.tcp_keepalive_time
 #   KEEPINTVL   <=>   net.ipv4.tcp_keepalive_intvl
-# Reduce the idle period (net.ipv4.tcp_keepalive_time) to 75 seconds
-# the Linux system default is 7200, or 2 hours, which is too long to be useful.
+# Reduce the idle period (net.ipv4.tcp_keepalive_time) to 75 seconds, since
+# the Linux system default of 7200, or 2 hours, is too long to be useful.
 ENV KEEPIDLE 75
 
 ENTRYPOINT ["/usr/local/bin/springboard", "/bin/bash", "/usr/local/bin/stunnel.sh"]


### PR DESCRIPTION
The springboard container used to be built from a hard-coded
stunnel container. Make it configurable to support a build
dependency chain.

This is still work in progress.

Update decco operator to deploy a specific springboard container version
that is built on an stunnel container that has TCP keepalive enabled ( see: https://github.com/platform9/stunnel/commit/163e6e1724dee75e9c3a027a448964a74888a5c0 )

The following 3 keepalive parameters can be overriden from their kernel
defaults using environment variables:
   KEEPCNT     <=>   net.ipv4.tcp_keepalive_probes
   KEEPIDLE    <=>   net.ipv4.tcp_keepalive_time
   KEEPINTVL   <=>   net.ipv4.tcp_keepalive_intvl

Next steps: wire the 3 builds together into a proper build dependency
chain, at which point we can remove the hard-coding of the springboard
container.