### PR TITLE
Bump version to v1.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SPRINGBOARD_IMAGE_MARKER=$(SPRINGBOARD_STAGE_DIR)/image-marker
 
 # Override with your own Docker registry tag(s)
 REPO_TAG ?= platform9/$(OPERATOR_IMAGE_NAME)
-VERSION ?= 1.0.1
+VERSION ?= v1.1.0
 BUILD_NUMBER ?= 000
 BUILD_ID := $(BUILD_NUMBER)
 IMAGE_TAG ?= $(VERSION)-$(BUILD_ID)


### PR DESCRIPTION
To highlight the separation of the `release-1.0` for `1.0.x` releases and `master` for non-`1.0.x` releases, this PR bumps up the version set on master to `1.1.0`.