### PR TITLE
[release-1.0] Bump version to v1.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SPRINGBOARD_IMAGE_MARKER=$(SPRINGBOARD_STAGE_DIR)/image-marker
 
 # Override with your own Docker registry tag(s)
 REPO_TAG ?= platform9/$(OPERATOR_IMAGE_NAME)
-VERSION ?= 1.0.1
+VERSION ?= v1.0.2
 BUILD_NUMBER ?= 000
 BUILD_ID := $(BUILD_NUMBER)
 IMAGE_TAG ?= $(VERSION)-$(BUILD_ID)


### PR DESCRIPTION
This release serves mostly as a final test whether the release workflow works as expected, but process-wise and technically. This version will include the following commit:
- 105b133b2de6f1bbf3d73a995582c05a5f90bfb2 - Improve test and release workflow (#19)