### PR TITLE
convert deployments to apiversion apps/v1

### DIFF
--- a/manifests/consul/consul-deployment.yaml
+++ b/manifests/consul/consul-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: consul

--- a/manifests/default-http-backend.yaml
+++ b/manifests/default-http-backend.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -7,6 +7,9 @@ metadata:
   namespace: decco
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: default-http-backend
   template:
     metadata:
       creationTimestamp: null

--- a/manifests/nginx-ingress-controller.yaml
+++ b/manifests/nginx-ingress-controller.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -7,6 +7,9 @@ metadata:
   namespace: decco
 spec:
   replicas: 0
+  selector:
+    matchLabels:
+      k8s-app: nginx-ingress
   template:
     metadata:
       annotations:

--- a/manifests/templates/decco-deployment.yaml.tmpl
+++ b/manifests/templates/decco-deployment.yaml.tmpl
@@ -6,11 +6,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: decco-operator
+      k8s-app: decco-operator
   template:
     metadata:
       labels:
-        name: decco-operator
+        k8s-app: decco-operator
     spec:
       serviceAccountName: decco-operator
       containers:

--- a/manifests/templates/decco-deployment.yaml.tmpl
+++ b/manifests/templates/decco-deployment.yaml.tmpl
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: decco-operator
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: decco-operator
   template:
     metadata:
       labels:

--- a/manifests/templates/k8sniff-deployment.yaml.tmpl
+++ b/manifests/templates/k8sniff-deployment.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: k8sniff


### PR DESCRIPTION
The Deployment resources for deploying the decco operator need updating for the kube 1.16 deprecation of extensions/v1beta1.