### PR TITLE
Improve the release workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ verify-goreleaser:
 .PHONY: verify-go
 verify-go:
 	# Check if codebase is formatted.
-	@bash -c "[ -z $$(gofmt -l ./api ./cmd ./pkg ./test) ] && echo 'OK' || (echo 'ERROR: files are not formatted:' && gofmt -l . && false)"
+	@bash -c "[ -z \"$$(gofmt -l ./api ./cmd ./pkg ./test)\" ] && echo 'OK' || (echo 'ERROR: files are not formatted:' && gofmt -l . && echo -e \"\nRun 'make format' or manually fix the formatting issues.\n\" && false)"
 	# Run static checks on codebase.
 	go vet ./api/... ./cmd/... ./pkg/... ./test/...
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# decco
-Deployment cluster configuration and operations for Kubernetes
+# Decco
+
+Deployment cluster configuration and operations for Kubernetes.
 
 ## Overview
 
@@ -20,10 +21,11 @@ Decco solves and automates the following problems:
 - Routing network requests to the correct application endpoints
 - Collecting and aggregating log files
 
-
-
 ## Developing
-Littering print statements throughout your code in order to debug complicated reconcilation loops can become difficult to reason about. With that said, this repo offers at least 1 opinionated way of setting break points for iterative development.
+Littering print statements throughout your code in order to debug complicated 
+reconcilation loops can become difficult to reason about. With that said, this 
+repo offers at least 1 opinionated way of setting break points for iterative 
+development.
 
 1. Create a file named `kubeconfig` at the root of this repo (same place as the Makefile)
 2. Have [vscode](https://code.visualstudio.com/) installed
@@ -55,3 +57,31 @@ just export an empty GO_TOOLCHAIN:
 ```bash
 export GO_TOOLCHAIN=""
 ```
+
+## Release Workflow
+
+Decco uses semantic versioning. To release a new version of Decco. 
+
+1. (a) If you are releasing a **major** or **minor** version, such as v1.0.0 or 
+   v1.3.0, you create a new branch, named `release-x.y`, where `x` and `y` are 
+   the major and minor version respectively. Or,
+   (b) if you are releasing a **patch**, such as 1.3.5, you check out the existing 
+   branch with the appropriate major and minor version. For example, fo 1.3.5
+   check out `release-1.3`.
+
+2. On the release branch, create and push a commit that bumps 
+   [VERSION](./VERSION) to your desired version. Do not push this commit to the 
+   master branch.
+
+3. If needed, thoroughly test the release branch.
+
+4. Then, run the (Platform9 internal) `decco-release` TeamCity build. This will
+   effectively run the release script: [./hack/ci-release.sh](./hack/ci-release.sh).
+   In a preconfigured environment you could run `make release` instead.   
+
+5. If everything succeeds, the version commit will be tagged, Github release 
+   will be created and Docker images will be published for the given version.
+   
+In case you need to revert a release, you will need to manually delete the git 
+tag, the github release, and delete the created Docker images. You will also 
+need to re-tag the previous images to `latest`.   

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Decco uses semantic versioning. To release a new version of Decco.
    v1.3.0, you create a new branch, named `release-x.y`, where `x` and `y` are 
    the major and minor version respectively. Or,
    (b) if you are releasing a **patch**, such as 1.3.5, you check out the existing 
-   branch with the appropriate major and minor version. For example, fo 1.3.5
+   branch with the appropriate major and minor version. For example, for 1.3.5
    check out `release-1.3`.
 
 2. On the release branch, create and push a commit that bumps 
@@ -77,7 +77,8 @@ Decco uses semantic versioning. To release a new version of Decco.
 
 4. Then, run the (Platform9 internal) `decco-release` TeamCity build. This will
    effectively run the release script: [./hack/ci-release.sh](./hack/ci-release.sh).
-   In a preconfigured environment you could run `make release` instead.   
+   Alternatively, in a preconfigured environment you could run `make release` 
+   instead.   
 
 5. If everything succeeds, the version commit will be tagged, Github release 
    will be created and Docker images will be published for the given version.

--- a/hack/ci-release.sh
+++ b/hack/ci-release.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# ci-release.sh - automated a release of Decco for CI systems. The version to
+#                 release is set in the VERSION file.
+#
+# The script assumes a Linux host with Docker and Make installed. It
+# installs all further prerequisites (like Go, goreleaser) and does the
+# git tagging. If you want to create a release without all this, you can use
+# `make release`.
+#
+# Expected environment variables:
+#
+# - DOCKER_PASSWORD       The password for the Docker account to push the images too.
+# - DOCKER_USERNAME       The username for the Docker account to push the images too.
+# - DOCKER_REGISTRY       The Docker registry to push the images too.
+# - DRY_RUN               If non-empty, no resulting artifacts will actually be published.
+# - GIT_USER_EMAIL        The email of the user creating the git tag.
+# - GIT_USER_NAME         The name of the user creating the git tag.
+# - GITHUB_TOKEN          A Github access token to publish the release.
+# - GO_VERSION            The version of Go to use.
+# - GORELEASER_VERSION    The version of goreleaser to use.
+
+# Configure Docker
+echo -n "${DOCKER_PASSWORD}" | docker login --password-stdin -u "${DOCKER_USERNAME}"
+
+# Install gimme
+mkdir -p ./bin
+export PATH="$(pwd)/bin:${PATH}"
+curl -sL -o ./bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+chmod +x ./bin/gimme
+gimme --version
+
+# Install go
+eval "$(GIMME_GO_VERSION=${GO_VERSION} gimme)"
+mkdir -p ./build/gopath
+export GOPATH="$(pwd)/build/gopath"
+go version
+
+# Gimme sets GOROOT. The Makefile redeclares GOROOT based on GO_TOOLCHAIN,
+# so we need this roundabout hack
+export GO_TOOLCHAIN=${GOROOT}
+
+# Install goreleaser
+curl -L -o ./bin/goreleaser.tar.gz https://github.com/goreleaser/goreleaser/releases/download/${GORELEASER_VERSION}/goreleaser_$(uname)_$(uname -m).tar.gz
+(cd ./bin && tar -xvf goreleaser.tar.gz)
+goreleaser -v
+export GORELEASER="goreleaser"
+
+# Determine the VERSION.
+if stat VERSION > /dev/null ; then
+  export VERSION=$(head -n 1 ./VERSION)
+else
+  export VERSION="$(grep 'VERSION ?= ' ./Makefile | sed -E 's/^VERSION \?= (.+)$/\1/g')"
+fi
+echo "VERSION=${VERSION}"
+
+# Make the release
+if [ -z "$DRY_RUN" ]
+then
+  # Tag the current/last commit with the VERSION (required by make release)
+  git config user.email "${GIT_USER_EMAIL}"
+  git config user.name "${GIT_USER_NAME}"
+  git status -b
+  git tag -a "${VERSION}" -m "${VERSION}"
+
+	make release
+else
+	make release-dry-run
+fi

--- a/hack/ci-release.sh
+++ b/hack/ci-release.sh
@@ -67,7 +67,7 @@ then
   git status -b
   git tag -a "${VERSION}" -m "${VERSION}"
 
-	make release
+  make release
 else
-	make release-dry-run
+  make release-dry-run
 fi

--- a/hack/ci-release.sh
+++ b/hack/ci-release.sh
@@ -16,7 +16,6 @@ set -o pipefail
 #
 # - DOCKER_PASSWORD       The password for the Docker account to push the images too.
 # - DOCKER_USERNAME       The username for the Docker account to push the images too.
-# - DOCKER_REGISTRY       The Docker registry to push the images too.
 # - DRY_RUN               If non-empty, no resulting artifacts will actually be published.
 # - GIT_USER_EMAIL        The email of the user creating the git tag.
 # - GIT_USER_NAME         The name of the user creating the git tag.


### PR DESCRIPTION
This PR improves a couple of things related to the release workflow:
- Document the steps that need to be performed for a release.
- Check-in the release CI script.

As a flyby, the output of `make verify` is clarified.